### PR TITLE
bucketへ画像を保存する処理追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,6 +63,7 @@ gem 'jquery-ui-rails'
 gem 'ranked-model'
 gem 'bootstrap-sass'
 gem 'httparty', '0.13.5'
+gem 'fog-aws'
 
 group :production do
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,10 +74,28 @@ GEM
       responders
       warden (~> 1.2.3)
     erubis (2.7.0)
+    excon (0.73.0)
     execjs (2.7.0)
     ffi (1.12.2)
+    fog-aws (3.6.4)
+      fog-core (~> 2.1)
+      fog-json (~> 1.1)
+      fog-xml (~> 0.1)
+      ipaddress (~> 0.8)
+    fog-core (2.2.0)
+      builder
+      excon (~> 0.71)
+      formatador (~> 0.2)
+      mime-types
+    fog-json (1.2.0)
+      fog-core
+      multi_json (~> 1.10)
+    fog-xml (0.1.3)
+      fog-core
+      nokogiri (>= 1.5.11, < 2.0.0)
     font-awesome-sass (5.12.0)
       sassc (>= 1.11)
+    formatador (0.2.5)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     haml (5.1.2)
@@ -102,6 +120,7 @@ GEM
     image_processing (1.10.3)
       mini_magick (>= 4.9.5, < 5)
       ruby-vips (>= 2.0.17, < 3)
+    ipaddress (0.8.3)
     jbuilder (2.10.0)
       activesupport (>= 5.0.0)
     jquery-rails (4.3.5)
@@ -120,11 +139,15 @@ GEM
     mail (2.7.1)
       mini_mime (>= 0.1.1)
     method_source (1.0.0)
+    mime-types (3.3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2020.0512)
     mimemagic (0.3.4)
     mini_magick (4.10.1)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.14.0)
+    multi_json (1.14.1)
     multi_xml (0.6.0)
     mysql2 (0.5.3)
     nio4r (2.5.2)
@@ -235,6 +258,7 @@ DEPENDENCIES
   carrierwave
   coffee-rails (~> 4.2)
   devise
+  fog-aws
   font-awesome-sass
   haml-rails
   httparty (= 0.13.5)

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -4,8 +4,14 @@ class ImageUploader < CarrierWave::Uploader::Base
   include CarrierWave::MiniMagick
 
   # Choose what kind of storage to use for this uploader:
-  storage :file
+  # storage :file
   # storage :fog
+
+  if Rails.env.development? || Rails.env.test?
+    storage :file
+  else
+    storage :fog
+  end
 
   # Override the directory where uploaded files will be stored.
   # This is a sensible default for uploaders that are meant to be mounted:

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -1,0 +1,20 @@
+require 'carrierwave/storage/abstract'
+require 'carrierwave/storage/file'
+require 'carrierwave/storage/fog'
+
+CarrierWave.configure do |config|
+  if Rails.env.development? || Rails.env.test?
+    config.storage = :file
+  else
+    config.storage = :fog
+    config.fog_provider = 'fog/aws'
+    config.fog_credentials = {
+      provider: 'AWS',
+      aws_access_key_id: ENV['AWS_ACCESS_KEY_ID'],
+      aws_secret_access_key: ENV['AWS_SECRET_ACCESS_KEY'],
+      region: 'ap-northeast-1'
+    }
+    config.fog_directory  = 'movieroom-bucket'
+    config.asset_host = 'https://s3-ap-northeast-1.amazonaws.com/movieroom-bucket'
+  end
+end


### PR DESCRIPTION
herokuだと画像保存がされないため
AWSのS３を使用して画像保存できるように設定。
gemでfog-awsを追加
/movie-room/app/uploaders/image_uploader.rb
条件分岐
開発環境ならpublic
本番環境ならS３
/movie-room/config/initializers/carrierwave.rb
以下のサイトを参考にした
https://qiita.com/kazyam/private/019e4a635479169c8704#%E8%A3%9C%E8%B6%B3s3%E5%B0%8E%E5%85%A5%E6%99%82%E3%81%AEaws%E3%82%AD%E3%83%BC%E3%81%AE%E5%8F%96%E3%82%8A%E6%89%B1%E3%81%84%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6