### PR TITLE
activesupportをGEMファイルに追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,6 +64,7 @@ gem 'ranked-model'
 gem 'bootstrap-sass'
 gem 'httparty', '0.13.5'
 gem 'fog-aws'
+gem 'activesupport'
 
 group :production do
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -253,6 +253,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activesupport
   bootstrap-sass
   byebug
   carrierwave


### PR DESCRIPTION
# WHAT
gemファイルにactivesupportを追加してbundle installした。

# Why
githubでセキュリティアラート出ていた為、指示に従った。