### PR TITLE
タイムゾーンを東京に修正

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -8,6 +8,8 @@ Bundler.require(*Rails.groups)
 
 module MovieRoom
   class Application < Rails::Application
+    config.time_zone = 'Tokyo'
+
     config.generators do |g|
       g.stylesheets false
       g.javascripts false


### PR DESCRIPTION
タイムゾーンが東京になっていなかった為、東京時間に修正した。