### PR TITLE
トップ画面の映画ポスターでビュー崩れが起きていた為修正

### DIFF
--- a/app/assets/stylesheets/modules/movies.scss
+++ b/app/assets/stylesheets/modules/movies.scss
@@ -7,3 +7,6 @@
     width: 500px; 
   }
 }
+.col-xs-3{
+  height: 400px;
+}


### PR DESCRIPTION
# What
トップ画面の映画ポスターでビュー崩れが起きていた為修正

# Why
ビューで映画ポスターの高さ指定がされていない為、
ビュー崩れが起きていた。